### PR TITLE
Read vcf.gz files in most circumstances

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "htslib"]
+	path = htslib
+	url = https://github.com/samtools/htslib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "htslib"]
-	path = htslib
-	url = https://github.com/samtools/htslib.git

--- a/SINGER/SINGER/Sampler.cpp
+++ b/SINGER/SINGER/Sampler.cpp
@@ -116,9 +116,9 @@ void Sampler::naive_read_vcf(string prefix, double start_pos, double end_pos) {
             continue;
         } // skip multi-allelic sites or structural variant
         
-        streampos old_pos = file.tellg();
+        streampos old_pos = file->tellg();
         string next_line;
-        if (getline(file, next_line)) {
+        if (getline(*file, next_line)) {
             istringstream next_iss(next_line);
             string next_chrom;
             int next_pos;
@@ -128,7 +128,7 @@ void Sampler::naive_read_vcf(string prefix, double start_pos, double end_pos) {
                 prev_pos = pos;
                 continue;
             }
-            file.seekg(old_pos);
+            file->seekg(old_pos);
         }
         int individual_index = 0;
         while (iss >> genotype) {

--- a/SINGER/SINGER/Sampler.cpp
+++ b/SINGER/SINGER/Sampler.cpp
@@ -52,9 +52,30 @@ void Sampler::set_num_samples(int n) {
     num_samples = n;
 }
 
+bool file_exists(const std::string& filename) {
+    std::ifstream f(filename);
+    return f.good();
+}
+
+std::unique_ptr<std::istream> open_vcf_stream(const std::string& filename) {
+    if (filename.size() > 3 && filename.substr(filename.size() - 3) == ".gz") {
+        return std::make_unique<gzistream>(filename.c_str());
+    } else {
+        auto f = std::make_unique<std::ifstream>(filename);
+        if (!f->is_open()) {
+            throw std::runtime_error("Failed to open file: " + filename);
+        }
+        return f;
+    }
+}
+
+
 void Sampler::naive_read_vcf(string prefix, double start_pos, double end_pos) {
-    string vcf_file = prefix + ".vcf";
-    ifstream file(vcf_file);
+    string vcf_file = prefix + ".vcf.gz";
+    if (!file_exists(vcf_file)) {
+        string vcf_file = prefix + ".vcf";
+    }
+    unique_ptr<istream> file = open_vcf_stream(vcf_file);
     string line;
     int num_individuals = 0;
     int prev_pos = -1;
@@ -62,7 +83,7 @@ void Sampler::naive_read_vcf(string prefix, double start_pos, double end_pos) {
     int valid_mutation = 0;
     int removed_mutation = 0;
     vector<double> genotypes = {};
-    while (getline(file, line)) {
+    while (getline(*file, line)) {
         if (line.substr(0, 6) == "#CHROM") {
             istringstream iss(line);
             vector<string> fields;
@@ -141,86 +162,72 @@ void Sampler::naive_read_vcf(string prefix, double start_pos, double end_pos) {
     cout << "removed mutations: " << removed_mutation << endl;
 }
 
-void Sampler::guide_read_vcf(string prefix, double start, double end) {
+void Sampler::guide_read_vcf(std::string prefix, double start, double end) {
     random_engine.seed(random_seed);
-    string vcf_file = prefix + ".vcf";
-    string index_file = prefix + ".index";
-    ifstream idx_stream(index_file);
-    if (!idx_stream.is_open()) {
-        cerr << "Index file not found: " + index_file << endl;
+    std::string vcf_file = prefix + ".vcf.gz";
+
+    htsFile* fp = bcf_open(vcf_file.c_str(), "r");
+    if (!fp) {
+        std::cerr << "VCF file not found: " << vcf_file << std::endl;
         exit(1);
     }
-    string line;
-    long byte_offset = -1;
-    while (getline(idx_stream, line)) {
-        istringstream iss(line);
-        double segment_start;
-        long offset;
-        iss >> segment_start >> offset;
-        if (segment_start == start) {
-            byte_offset = offset;
-            break;
-        }
-    }
-    if (byte_offset == -1) {
-        cerr << "Start position not found in index file: " + index_file << endl;
+
+    bcf_hdr_t* hdr = bcf_hdr_read(fp);
+    if (!hdr) {
+        std::cerr << "Failed to read VCF header: " << vcf_file << std::endl;
         exit(1);
     }
-    ifstream vcf_stream(vcf_file, ios::binary);
-    if (!vcf_stream.is_open()) {
-        cerr << "VCF file not found: " + vcf_file << endl;
+
+    hts_idx_t* idx = bcf_index_load(vcf_file.c_str());
+    if (!idx) {
+        std::cerr << "Index (.tbi or .csi) not found for VCF file: " << vcf_file << std::endl;
+        exit(1);
     }
-    vcf_stream.seekg(byte_offset, ios::beg);
-    int prev_pos = -1;
-    vector<Node_ptr> nodes = {};
+
+    std::string region = "chr1:" + std::to_string((int)start) + "-" + std::to_string((int)end); // Adjust chr name as needed
+    hts_itr_t* itr = bcf_itr_querys(idx, hdr, region.c_str());
+    if (!itr) {
+        std::cerr << "Could not create iterator for region: " << region << std::endl;
+        exit(1);
+    }
+
+    bcf1_t* rec = bcf_init();
+    std::vector<Node_ptr> nodes;
+    std::vector<double> genotypes;
     int valid_mutation = 0;
     int removed_mutation = 0;
-    vector<double> genotypes = {};
-    while (getline(vcf_stream, line)) {
-        istringstream iss(line);
-        string chrom, id, ref, alt, qual, filter, info, format, genotype;
-        int pos;
-        iss >> chrom >> pos >> id >> ref >> alt >> qual >> filter >> info >> format;
-        if (pos == prev_pos) {continue;} // skip multi-allelic sites
-        if (pos >= end) {break;} // variant out of scope
-        if (ref.size() > 1 or alt.size() > 1) {
-            removed_mutation += 1;
-            continue;
-        } // skip multi-allelic sites or structural variant
-        streampos old_pos = vcf_stream.tellg();
-        string next_line;
-        if (getline(vcf_stream, next_line)) {
-            istringstream next_iss(next_line);
-            string next_chrom;
-            int next_pos;
-            next_iss >> next_chrom >> next_pos;
-            if (next_pos == pos) {
-                removed_mutation += 1;
-                prev_pos = pos;
-                continue;
-            }
-            vcf_stream.seekg(old_pos);
+    int prev_pos = -1;
+
+    while (bcf_itr_next(fp, itr, rec) >= 0) {
+        bcf_unpack(rec, BCF_UN_ALL);
+
+        int pos = rec->pos + 1; // VCF is 0-based, adjust to 1-based
+        if (pos >= end || pos == prev_pos) continue;
+        prev_pos = pos;
+
+        if (rec->n_allele != 2 || strlen(rec->d.allele[0]) != 1 || strlen(rec->d.allele[1]) != 1) {
+            removed_mutation++;
+            continue; // skip multiallelic or structural
         }
-        int individual_index = 0;
-        while (iss >> genotype) {
-            if (genotypes.size() < 2*individual_index + 2) {
-                genotypes.resize(2*individual_index + 2);
-            }
-            if (genotype[0] == '1') {
-                genotypes[2*individual_index] = 1;
-            } else {
-                genotypes[2*individual_index] = 0;
-            }
-            if (genotype[2] == '1') {
-                genotypes[2*individual_index + 1] = 1;
-            } else {
-                genotypes[2*individual_index + 1] = 0;
-            }
-            individual_index += 1;
+
+        int ngt_arr = 0, ngt = 0;
+        int32_t* gt_arr = NULL;
+        ngt = bcf_get_genotypes(hdr, rec, &gt_arr, &ngt_arr);
+        if (ngt <= 0) continue;
+
+        int n_samples = bcf_hdr_nsamples(hdr);
+        if (genotypes.size() < (size_t)(2 * n_samples)) genotypes.resize(2 * n_samples);
+
+        for (int i = 0; i < n_samples; ++i) {
+            int32_t a = bcf_gt_allele(gt_arr[2*i]);
+            int32_t b = bcf_gt_allele(gt_arr[2*i + 1]);
+            genotypes[2*i] = a == 1 ? 1 : 0;
+            genotypes[2*i + 1] = b == 1 ? 1 : 0;
         }
-        if (nodes.size() == 0) {
+
+        if (nodes.empty()) {
             nodes.resize(genotypes.size());
-            for (int i = 0; i < nodes.size(); i++) {
+            for (int i = 0; i < nodes.size(); ++i) {
                 nodes[i] = new_node(0.0);
                 nodes[i]->set_index(i);
                 sample_nodes.insert(nodes[i]);
@@ -228,26 +235,36 @@ void Sampler::guide_read_vcf(string prefix, double start, double end) {
         } else {
             assert(nodes.size() == genotypes.size());
         }
-        int genotype_sum = accumulate(genotypes.begin(), genotypes.end(), 0.0);
-        if (genotype_sum >= 1 and genotype_sum < genotypes.size()) {
-            valid_mutation += 1;
-            for (int i = 0; i < genotypes.size(); i++) {
+
+        int genotype_sum = std::accumulate(genotypes.begin(), genotypes.end(), 0.0);
+        if (genotype_sum >= 1 && genotype_sum < genotypes.size()) {
+            valid_mutation++;
+            for (int i = 0; i < genotypes.size(); ++i) {
                 if (genotypes[i] == 1) {
                     nodes[i]->add_mutation(pos - start);
                 }
             }
         }
+        free(gt_arr);
     }
+
+    bcf_destroy(rec);
+    hts_itr_destroy(itr);
+    bcf_hdr_destroy(hdr);
+    bcf_close(fp);
+    hts_idx_destroy(idx);
+
     if (valid_mutation < 3) {
-        cerr << "there are too few variants in this region, algorithm not run" << endl;
+        std::cerr << "Too few variants in region, algorithm not run" << std::endl;
     }
+
     num_samples = (int) sample_nodes.size();
-    ordered_sample_nodes = vector<Node_ptr>(sample_nodes.begin(), sample_nodes.end());
-    // shuffle(ordered_sample_nodes.begin(), ordered_sample_nodes.end(), random_engine);
+    ordered_sample_nodes = std::vector<Node_ptr>(sample_nodes.begin(), sample_nodes.end());
     sequence_length = end - start;
-    cout << "valid mutations: " << valid_mutation << endl;
-    cout << "removed mutations: " << removed_mutation << endl;
+    std::cout << "valid mutations: " << valid_mutation << std::endl;
+    std::cout << "removed mutations: " << removed_mutation << std::endl;
 }
+
 
 void Sampler::load_vcf(string prefix, double start, double end) {
     string index_file = prefix + ".index";

--- a/SINGER/SINGER/Sampler.hpp
+++ b/SINGER/SINGER/Sampler.hpp
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <chrono>
 #include <sstream>
+#include <zlib.h>
 #include "ARG.hpp"
 #include "Threader_smc.hpp"
 #include "Binary_emission.hpp"

--- a/SINGER/SINGER/Sampler.hpp
+++ b/SINGER/SINGER/Sampler.hpp
@@ -20,9 +20,6 @@
 #include "Scaler.hpp"
 #include "Rate_map.hpp"
 #include "gzstream.hpp"
-#include <htslib/vcf.h>
-#include <htslib/hts.h>
-#include <htslib/tbx.h>
 #include <iostream>
 #include <fstream>
 #include <vector>

--- a/SINGER/SINGER/Sampler.hpp
+++ b/SINGER/SINGER/Sampler.hpp
@@ -20,6 +20,17 @@
 #include "Scaler.hpp"
 #include "Rate_map.hpp"
 #include "gzstream.hpp"
+#include <htslib/vcf.h>
+#include <htslib/hts.h>
+#include <htslib/tbx.h>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <cassert>
+#include <numeric>
+#include <unordered_set>
+#include <random>
 
 class Sampler {
     

--- a/SINGER/SINGER/Sampler.hpp
+++ b/SINGER/SINGER/Sampler.hpp
@@ -19,6 +19,7 @@
 #include "Normalizer.hpp"
 #include "Scaler.hpp"
 #include "Rate_map.hpp"
+#include "gzstream.hpp"
 
 class Sampler {
     

--- a/SINGER/SINGER/gzstream.hpp
+++ b/SINGER/SINGER/gzstream.hpp
@@ -1,0 +1,49 @@
+#ifndef GZSTREAM_H
+#define GZSTREAM_H
+
+#include <streambuf>
+#include <istream>
+#include <zlib.h>
+#include <stdexcept>
+
+class gzstreambuf : public std::streambuf {
+public:
+    explicit gzstreambuf(const char* filename, size_t bufsize = 8192)
+        : buffer(bufsize), file(gzopen(filename, "rb")) {
+        if (!file)
+            throw std::runtime_error("Failed to open gzipped file");
+        setg(buffer.data(), buffer.data(), buffer.data());
+    }
+
+    ~gzstreambuf() {
+        if (file) gzclose(file);
+    }
+
+protected:
+    int_type underflow() override {
+        if (gzeof(file)) return traits_type::eof();
+
+        int bytes = gzread(file, buffer.data(), buffer.size());
+        if (bytes <= 0) return traits_type::eof();
+
+        setg(buffer.data(), buffer.data(), buffer.data() + bytes);
+        return traits_type::to_int_type(*gptr());
+    }
+
+private:
+    std::vector<char> buffer;
+    gzFile file;
+};
+
+class gzistream : public std::istream {
+public:
+    explicit gzistream(const char* filename)
+        : std::istream(nullptr), buf(filename) {
+        rdbuf(&buf);
+    }
+
+private:
+    gzstreambuf buf;
+};
+
+#endif // GZSTREAM_H

--- a/SINGER/SINGER/singer_master
+++ b/SINGER/SINGER/singer_master
@@ -5,7 +5,8 @@ import os
 import subprocess
 import argparse
 import random
-# import uuid
+import uuid
+import gzip
 import numpy as np
 # import pysam
 from pathlib import Path
@@ -161,7 +162,7 @@ def calculate_diversity(vcf_file, start, end):
     return nucleotide_diversity
 
 def compute_Ne(vcf_prefix, start, end, m):
-    if Path(vcf_prefix + ".vcf.gz").exist()
+    if Path(vcf_prefix + ".vcf.gz").exists():
         vcf_filename = vcf_prefix + ".vcf.gz" 
     else: vcf_filename = vcf_prefix + ".vcf"
     diversity = calculate_diversity(vcf_filename, start, end)

--- a/SINGER/SINGER/singer_master
+++ b/SINGER/SINGER/singer_master
@@ -8,6 +8,14 @@ import random
 # import uuid
 import numpy as np
 # import pysam
+from pathlib import Path
+
+# from stackoverflow: https://stackoverflow.com/questions/41525690/open-file-depending-on-whether-its-gz-or-not
+def openfile(filename, mode='r'):
+    if filename.endswith('gz'):
+        return gzip.open(filename, mode)
+    else:
+        return open(filename, mode)
 
 def random_string():
     unique_id = uuid.uuid4().hex
@@ -104,7 +112,7 @@ def calculate_diversity(vcf_file, start, end):
     num_variants = 0
 
     # Open the VCF file and read it line by line
-    with open(vcf_file, 'r') as vcf:
+    with openfile(vcf_file, 'r') as vcf:
         for line in vcf:
             # Skip header lines
             if line.startswith("#"):
@@ -153,7 +161,9 @@ def calculate_diversity(vcf_file, start, end):
     return nucleotide_diversity
 
 def compute_Ne(vcf_prefix, start, end, m):
-    vcf_filename = vcf_prefix + ".vcf"
+    if Path(vcf_prefix + ".vcf.gz").exist()
+        vcf_filename = vcf_prefix + ".vcf.gz" 
+    else: vcf_filename = vcf_prefix + ".vcf"
     diversity = calculate_diversity(vcf_filename, start, end)
     Ne = diversity/4/m
     return Ne 


### PR DESCRIPTION
Basically makes it so that when (a) singer is not using indexed mode, and (b) singer can find a .vcf.gz file, it preferentially uses that, and set up gzip streaming to ensure this can be read.

Future bugfix is that it will try and use .vcf.gz for indexed mode too (I think) unless no gz file present.

Note that zlib needs to be included in cmake for this all to work well:

With e.g. target_link_libraries(singer, z)